### PR TITLE
Document where dshot documentation is found

### DIFF
--- a/src/main/drivers/dshot.c
+++ b/src/main/drivers/dshot.c
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  *
  * Author: jflyper
+ *
+ * Follows the extended dshot telemetry documentation found at https://github.com/bird-sanctuary/extended-dshot-telemetry
  */
 
 #include <stdbool.h>


### PR DESCRIPTION
To make it easier for other developers to understand dshot I have added documentation that points anyone looking at the betaflight dshot.c file to https://github.com/bird-sanctuary/extended-dshot-telemetry to find the dshot standard.